### PR TITLE
feat!: don't read `strict` from tsconfig.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,6 @@ export function convertTsConfig(
     jsxFactory = 'React.createElement',
     jsxFragmentFactory = 'React.Fragment',
     jsxImportSource = 'react',
-    strict = false,
     alwaysStrict = false,
     noImplicitUseStrict = false,
     paths,
@@ -44,7 +43,7 @@ export function convertTsConfig(
       sourceMaps: sourceMap,
       module: {
         type: ['commonjs', 'amd', 'umd'].includes(module) ? module : 'commonjs',
-        strict,
+        strict: false,
         strictMode: alwaysStrict || !noImplicitUseStrict,
         noInterop: !esModuleInterop,
       } as swcType.ModuleConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,6 @@ export function convertTsConfig(
       sourceMaps: sourceMap,
       module: {
         type: ['commonjs', 'amd', 'umd'].includes(module) ? module : 'commonjs',
-        strict: false,
         strictMode: alwaysStrict || !noImplicitUseStrict,
         noInterop: !esModuleInterop,
       } as swcType.ModuleConfig,

--- a/test/index.ts
+++ b/test/index.ts
@@ -33,3 +33,9 @@ test('convert tsconfig file', (t) => {
 
   t.end()
 })
+
+test('ignores strict from tsconfig', (t) => {
+  const result = convert()
+  t.equal(result.module?.strict, false)
+  t.end()
+})

--- a/test/index.ts
+++ b/test/index.ts
@@ -36,6 +36,6 @@ test('convert tsconfig file', (t) => {
 
 test('ignores strict from tsconfig', (t) => {
   const result = convert()
-  t.equal(result.module?.strict, false)
+  t.equal(result.module?.strict, undefined)
   t.end()
 })


### PR DESCRIPTION
tsconfig's definition of strict is different to swc's, so we shouldn't treat them as the same field.

Default swc strict mode to false. It can still be overridden by manual config if required.

Fixes #10.