### PR TITLE
feat: add more tsconfig `module` options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,10 +92,10 @@ export function convertTsConfig(
 const availableModuleTypes = ['commonjs', 'amd', 'umd', 'es6'] as const
 type Module = (typeof availableModuleTypes)[number]
 
-function moduleType(m: string): Module {
+function moduleType(m: tsType.ModuleKind | undefined): Module {
   const module = (m as unknown as string)?.toLowerCase()
   if (availableModuleTypes.includes(module as any)) {
-    return module
+    return module as Module
   }
 
   const es6Modules = ['es2015', 'es2020', 'es2022', 'esnext'] as const

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export function convertTsConfig(
     experimentalDecorators = false,
     emitDecoratorMetadata = false,
     target = 'es3',
-    module: _module,
+    module,
     jsx: _jsx,
     jsxFactory = 'React.createElement',
     jsxFragmentFactory = 'React.Fragment',
@@ -39,9 +39,6 @@ export function convertTsConfig(
     paths,
     baseUrl,
   } = tsOptions
-  const module = (_module as unknown as string)?.toLowerCase()
-
-  const availableModuleTypes = ['commonjs', 'amd', 'umd', 'es6'] as const
 
   const jsx = (_jsx as unknown as string)?.toLowerCase()
   const jsxRuntime: swcType.ReactConfig['runtime'] =
@@ -53,9 +50,7 @@ export function convertTsConfig(
     {
       sourceMaps: sourceMap,
       module: {
-        type: availableModuleTypes.includes(module as any)
-          ? (module as (typeof availableModuleTypes)[number])
-          : 'commonjs',
+        type: moduleType(module),
         strictMode: alwaysStrict || !noImplicitUseStrict,
         noInterop: !esModuleInterop,
       } satisfies swcType.ModuleConfig,
@@ -92,4 +87,21 @@ export function convertTsConfig(
   )
 
   return transformedOptions
+}
+
+const availableModuleTypes = ['commonjs', 'amd', 'umd', 'es6'] as const
+type Module = (typeof availableModuleTypes)[number]
+
+function moduleType(m: string): Module {
+  const module = (m as unknown as string)?.toLowerCase()
+  if (availableModuleTypes.includes(module as any)) {
+    return module
+  }
+
+  const es6Modules = ['es2015', 'es2020', 'es2022', 'esnext'] as const
+  if (es6Modules.includes(module as any)) {
+    return 'es6'
+  }
+
+  return 'commonjs'
 }

--- a/test/fixtures/tsconfig/tsconfig-es2022.json
+++ b/test/fixtures/tsconfig/tsconfig-es2022.json
@@ -1,0 +1,17 @@
+{
+  // test should read this file correctly
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "sourceMap": false,
+    "importHelpers": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "es2022",
+    "jsxFactory": "React.createElement",
+    "jsxFragmentFactory": "React.Fragment",
+    "strict": true,
+    "alwaysStrict": true,
+    "noImplicitUseStrict": true
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -40,4 +40,13 @@ describe.concurrent('convert', () => {
     // @ts-ignore
     expect(result.module?.strict).toBe(undefined)
   })
+
+  it('should ignore strict from tsconfig', ({ expect }) => {
+    const result = convert(
+      'tsconfig-es2022.json',
+      path.resolve(__dirname, 'fixtures', 'tsconfig'),
+    )
+    // @ts-ignore
+    expect(result.module?.type).toBe('es6')
+  })
 })


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig#module

Converts es2015 es2020 es2022 esnext to es6 as well when running the conversation.