### PR TITLE
fix: do not modify joycon-cached config

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,15 +31,11 @@ export function getTSOptions(
   return compilerOptions ?? null
 }
 
-function loadTsFile(filename: string, cwd: string, tsConfig?: any): any {
+function loadTsFile(filename: string, cwd: string): any {
   let { data, path } = resolveFile(filename, cwd) ?? {}
 
   if (!path || !data) {
-    return tsConfig
-  }
-
-  if (tsConfig) {
-    data = deepmerge(data, tsConfig)
+    return null
   }
 
   if (!data.extends) {
@@ -47,12 +43,11 @@ function loadTsFile(filename: string, cwd: string, tsConfig?: any): any {
   }
 
   const extendsArr = Array.isArray(data.extends) ? data.extends : [data.extends]
-  delete data.extends
   for (let _extends of extendsArr) {
     if (!_extends.endsWith('.json')) {
       _extends += '.json'
     }
-    data = loadTsFile(_extends, cwd, data)
+    data = deepmerge(loadTsFile(_extends, cwd), data)
   }
 
   return data

--- a/test/fixtures/tsconfig/tsconfig-extends-no-target-child.json
+++ b/test/fixtures/tsconfig/tsconfig-extends-no-target-child.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig-extends-no-target",
+  "compilerOptions": {
+    "strict": false
+  }
+}

--- a/test/fixtures/tsconfig/tsconfig-extends-no-target.json
+++ b/test/fixtures/tsconfig/tsconfig-extends-no-target.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig",
+  "compilerOptions": {}
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -27,6 +27,22 @@ describe.concurrent('getTSOptions', () => {
     expect(result).toMatchObject({ target: 'es2018', strict: true })
   })
 
+  it('should read extended tsconfig with no target set', ({ expect }) => {
+    let result = getTSOptions(
+      'tsconfig-extends-no-target.json',
+      path.resolve(__dirname, 'fixtures', 'tsconfig'),
+    )
+    expect(result).toMatchObject({ target: 'esnext', strict: true })
+  })
+
+  it('should read multiple extended tsconfig with no target set', ({ expect }) => {
+    let result = getTSOptions(
+      'tsconfig-extends-no-target-child.json',
+      path.resolve(__dirname, 'fixtures', 'tsconfig'),
+    )
+    expect(result).toMatchObject({ target: 'esnext', strict: false })
+  })
+
   it('should read extended tsconfig in node_modules', ({ expect }) => {
     let result = getTSOptions(
       'tsconfig-extends-imported.json',


### PR DESCRIPTION
It seems like `joycon` caches the loaded config files, then those cached objects are modified by `tsconfig-to-swcconfig`, and any further use of that modified object seems broken.

The tests were created by me trying to simulate my use case, they aren't the greatest for testing the actual bug. IMO just removing `joycon` would be a better fix but I thought I'd keep the diff minimal for now.

Note that invoking `joycon.clearCache()` also fixes it.

However this doesn't seem to fix my original issue which I'm still investigating :/