### PR TITLE
fix: support tsconfig target:es6

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,9 +106,11 @@ function moduleType(m: tsType.ModuleKind | undefined): Module {
   return 'commonjs'
 }
 
-function targetType(m: string): swcType.JscTarget {
-  // ts: https://www.typescriptlang.org/tsconfig#target
+function targetType(t: string): swcType.JscTarget {
+  // ts: "es3" | "es5"| "es6" | "es2015"| "es2016"| "es2017"| "es2018"| "es2019"| "es2020"| "es2021"| "es2022"| "esnext";
+  // @see https://www.typescriptlang.org/tsconfig#target
   // swc: "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext";
 
-  return m === 'es6' ? 'es2015' : m as swcType.JscTarget
+  t = t.toLowerCase()
+  return t === 'es6' ? 'es2015' : (t as swcType.JscTarget)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ export function convertTsConfig(
       } satisfies swcType.ModuleConfig,
       jsc: {
         externalHelpers: importHelpers,
-        target: target as swcType.JscTarget,
+        target: targetType(target as any),
         parser: {
           syntax: 'typescript',
           tsx: true,
@@ -104,4 +104,11 @@ function moduleType(m: tsType.ModuleKind | undefined): Module {
   }
 
   return 'commonjs'
+}
+
+function targetType(m: string): swcType.JscTarget {
+  // ts: https://www.typescriptlang.org/tsconfig#target
+  // swc: "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext";
+
+  return m === 'es6' ? 'es2015' : m as swcType.JscTarget
 }

--- a/test/fixtures/tsconfig/tsconfig-es6.json
+++ b/test/fixtures/tsconfig/tsconfig-es6.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+      "target": "es6"
+    }
+  }
+  

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -49,4 +49,13 @@ describe.concurrent('convert', () => {
     // @ts-ignore
     expect(result.module?.type).toBe('es6')
   })
+
+  it('should support target es6', ({ expect }) => {
+    const result = convert(
+      'tsconfig-es6.json',
+      path.resolve(__dirname, 'fixtures', 'tsconfig'),
+    )
+    // @ts-ignore
+    expect(result.jsc?.target).toBe('es2015')
+  })
 })


### PR DESCRIPTION
It seems like swc doesn't support "es6" and you must use the equivalent "es2015"?

tsconfig: https://www.typescriptlang.org/tsconfig#target
swcrc: https://swc.rs/docs/configuration/compilation#jsctarget (which doesn't document the valid values)