### PR TITLE
fix: support --set boolean and numberic params

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Options:
   -f, --filename <filename>  filename to tsconfig (default: "tsconfig.json")
   -c, --cwd <cwd>            cwd (default: process.cwd())
   -o, --output <output>      output file (default: stdout)
+  -s, --set <name>=<value>   set additional swcrc options
   -h, --help                 display help for command
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { writeFile } from 'node:fs'
 import { parseArgs } from 'node:util'
 import type swcType from '@swc/core'
 import { convert } from './index'
+import { parseParamValue } from './utils'
 
 const {
 	values: { filename, cwd, output, help, set: overrideValues },
@@ -62,7 +63,7 @@ const overrides = overrideValues?.reduce((all, a) => {
 		return o[s]
 	}, all)
 
-	parent[key] = value
+	parent[key] = parseParamValue(prop, value)
 
 	return all
 }, {} as any) as swcType.Options

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,3 +71,13 @@ function resolveFile(
 		return null
 	}
 }
+
+export function parseParamValue(prop: string, value: string) {
+	if (value === "true" || value === "false") {
+	  return value === "true"
+	}
+	if (!isNaN(Number(value))) {
+	  return Number(value)
+	}
+	return value
+  }

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -56,4 +56,36 @@ describe('cli', { concurrency: true }, () => {
 		match(stdout, /"target": "es2015"/)
 		match(stdout, /"type": "commonjs"/)
 	})
+
+	it('should convert tsconfig.json with boolean additions', async () => {
+		const { stdout, stderr } = await pExe('node', [
+			'dist/cli.js',
+			'--set',
+			'jsc.externalHelpers=true',
+			'--set',
+			'jsc.test2=false',
+		])
+		strictEqual(stderr, '')
+		match(stdout, /"externalHelpers": true/)
+		match(stdout, /"test2": false/)
+	})
+
+	it('should convert tsconfig.json with numeric additions', async () => {
+		const { stdout, stderr } = await pExe('node', [
+			'dist/cli.js',
+			'--set',
+			'jsc.num1=1',
+			'--set',
+			'jsc.num2=2',
+			'--set',
+			'jsc.not1=1x',
+			'--set',
+			'jsc.not2=x2',
+		])
+		strictEqual(stderr, '')
+		match(stdout, /"num1": 1/)
+		match(stdout, /"num2": 2/)
+		match(stdout, /"not1": "1x"/)
+		match(stdout, /"not2": "x2"/)
+	})
 })


### PR DESCRIPTION
Didn't think of this one at first. Note that we'll have the same issue with numbers if there are any numeric options.