### PR TITLE
feat: support removal of properties with --set name=undefined

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,11 +73,12 @@ function resolveFile(
 }
 
 export function parseParamValue(prop: string, value: string) {
-	if (value === 'true' || value === 'false') {
-		return value === 'true'
+	if (value === 'undefined') {
+		return undefined
 	}
-	if (!isNaN(Number(value))) {
-		return Number(value)
+	try {
+		return JSON.parse(value)
+	} catch (_) {
+		return value
 	}
-	return value
 }

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,4 +1,4 @@
-import { match, ok, strictEqual } from 'node:assert'
+import { match, doesNotMatch, ok, strictEqual } from 'node:assert'
 import { execFile } from 'node:child_process'
 import { dirname, resolve } from 'node:path'
 import { describe, it } from 'node:test'
@@ -42,6 +42,16 @@ describe('cli', { concurrency: true }, () => {
 		match(stdout, /"target": "es2015"/)
 	})
 
+	it('should convert tsconfig.json with explicit-string additions', async () => {
+		const { stdout, stderr } = await pExe('node', [
+			'dist/cli.js',
+			'--set',
+			'module.target="es2015"',
+		])
+		strictEqual(stderr, '')
+		match(stdout, /"target": "es2015"/)
+	})
+
 	it('should convert tsconfig.json with additions', async () => {
 		const { stdout, stderr } = await pExe('node', [
 			'dist/cli.js',
@@ -68,6 +78,45 @@ describe('cli', { concurrency: true }, () => {
 		strictEqual(stderr, '')
 		match(stdout, /"externalHelpers": true/)
 		match(stdout, /"test2": false/)
+	})
+
+	it('should convert tsconfig.json with undefined additions', async () => {
+		const { stdout, stderr } = await pExe('node', [
+			'dist/cli.js',
+			'--filename',
+			resolve(__dirname, 'fixtures', 'tsconfig', 'tsconfig-paths.json'),
+			'--set',
+			'jsc.paths=undefined',
+		])
+		strictEqual(stderr, '')
+		doesNotMatch(stdout, /"paths": /)
+		match(stdout, /"baseUrl": "src"/)
+	})
+
+	it('should convert tsconfig.json with "undefined" string addition', async () => {
+		const { stdout, stderr } = await pExe('node', [
+			'dist/cli.js',
+			'--filename',
+			resolve(__dirname, 'fixtures', 'tsconfig', 'tsconfig.json'),
+			'--set',
+			'jsc.paths.foo="undefined"',
+		])
+		strictEqual(stderr, '')
+		match(stdout, /"foo": "undefined"/)
+	})
+
+	it('should convert tsconfig.json with undefined additions on parent', async () => {
+		const { stdout, stderr } = await pExe('node', [
+			'dist/cli.js',
+			'--filename',
+			resolve(__dirname, 'fixtures', 'tsconfig', 'tsconfig-paths.json'),
+			'--set',
+			'jsc=undefined',
+		])
+		strictEqual(stderr, '')
+		doesNotMatch(stdout, /"jsc": /)
+		doesNotMatch(stdout, /"paths": /)
+		doesNotMatch(stdout, /"baseUrl": /)
 	})
 
 	it('should convert tsconfig.json with numeric additions', async () => {

--- a/test/fixtures/tsconfig/tsconfig-paths.json
+++ b/test/fixtures/tsconfig/tsconfig-paths.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "lib-a": "../../other/a"
+    }
+  }
+}


### PR DESCRIPTION
WDYT of this one?

I've had a few cases where I need to remove properties. The common one being `jsc.paths` and `jsc.baseUrl` because they work differently then with tsc (swc rewrites imports to follow paths, typescript does not).

This adds `undefined` support, then `JSON.stringify` will remove the property. I'm not sure if swc has any properties where `null` is a valid value, but if so that would be another minor addition to the `parseParamValue` method.

The other option would be `--del jsc.paths` instead of using `undefined`, then we don't have to make the `parseParamValue` more complicated? But more cli params makes the CLI more complicated, and would not solve the `null` case if that is ever needed 🤷 