### PR TITLE
fix: support for "module": "node16"/"nodenext"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,16 +107,17 @@ function moduleType(
 		'es2020',
 		'es2022',
 		'esnext',
-		'node16',
-		'nodenext',
 		'none',
 	] as const
 	if (es6Modules.includes(module as any)) {
 		return 'es6'
 	}
 
-	const packageJson = getPackageJson(cwd)
-	if (packageJson?.type === 'module') {
+	const nodeModules = [
+		'node16',
+		'nodenext',
+	] as const
+	if (nodeModules.includes(module as any) && getPackageJson(cwd)?.type === 'module') {
 		return 'es6'
 	}
 

--- a/test/fixtures/tsconfig-with-package-json/tsconfig.json
+++ b/test/fixtures/tsconfig-with-package-json/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "module": "node16",
     "target": "esnext",
     "strict": true
   }


### PR DESCRIPTION
With `"module": "node16"` and `"module": "nodenext"`, look at package.json to determine whether module type is es6 or commonjs. Previously, these values would unconditionally be treated as es6.

https://github.com/songkeys/tsconfig-to-swcconfig/issues/23